### PR TITLE
Live display layer updates when editing with the display layer visible in editor

### DIFF
--- a/addons/dualgrid/dualgrid.gd
+++ b/addons/dualgrid/dualgrid.gd
@@ -26,8 +26,6 @@ extends TileMapLayer
 		hide_display_layers()
 		_editor_display_layer_visible = false
 	else:
-		_sync_inherited_properties()
-		update_all_tiles()
 		show_display_layers()
 		_editor_display_layer_visible = true
 
@@ -170,11 +168,6 @@ func _ready() -> void:
 		hide_display_layers()
 
 
-func _notification(what: int) -> void:
-	if what == NOTIFICATION_EDITOR_PRE_SAVE:
-		_cache_display_layers()
-
-
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: PackedStringArray = []
 
@@ -193,8 +186,12 @@ func _set(property: StringName, value: Variant) -> bool:
 				tile_set.changed.disconnect(_update_display_layer_position_offset)
 			new_tile_set.changed.connect(_update_display_layer_position_offset)
 			tile_set = new_tile_set
+			_set_display_layer_property(property, new_tile_set)
 			update_configuration_warnings()
 			return true
+	
+	if INHERITED_PROPERTIES.has(property):
+		_set_display_layer_property(property, value)
 
 	return false
 
@@ -427,11 +424,6 @@ func _is_world_tile_occupied_by_source(world_coords: Vector2i, souce_id: int) ->
 	if souce_id == _NULL_SOURCE_ID:
 		return false
 	return get_cell_source_id(world_coords) == souce_id
-
-
-func _cache_display_layers() -> void:
-	_sync_inherited_properties()
-	update_all_tiles()
 
 
 ## Makes the display layers visible and hides the world grid.

--- a/addons/dualgrid/dualgrid.gd
+++ b/addons/dualgrid/dualgrid.gd
@@ -199,6 +199,13 @@ func _set(property: StringName, value: Variant) -> bool:
 	return false
 
 
+## Override virtual function to update the display layer tiles when world tiles are changed 
+func _update_cells(coords: Array[Vector2i], forced_cleanup: bool) -> void:
+	if not Engine.is_editor_hint(): return
+	for world_coords: Vector2i in coords:
+		_set_display_tiles_for_world_tile(world_coords)
+
+
 ## Sets a property on all internal TileMapLayers
 func _set_display_layer_property(property: StringName, value: Variant) -> void:
 	for layer: TileMapLayer in _mix_layers:

--- a/addons/dualgrid/dualgrid.gd
+++ b/addons/dualgrid/dualgrid.gd
@@ -200,6 +200,7 @@ func _set(property: StringName, value: Variant) -> bool:
 func _update_cells(coords: Array[Vector2i], forced_cleanup: bool) -> void:
 	if forced_cleanup: return
 	if not Engine.is_editor_hint(): return
+	
 	for world_coords: Vector2i in coords:
 		_set_display_tiles_for_world_tile(world_coords)
 
@@ -220,6 +221,7 @@ func _setup_layers() -> void:
 
 	for layer: TileMapLayer in _mix_layers:
 		add_child(layer)
+		layer.owner = self
 
 	_sync_inherited_properties()
 	_set_display_layer_property(&"collision_enabled", display_collision_enabled)

--- a/addons/dualgrid/dualgrid.gd
+++ b/addons/dualgrid/dualgrid.gd
@@ -198,6 +198,7 @@ func _set(property: StringName, value: Variant) -> bool:
 
 ## Override virtual function to update the display layer tiles when world tiles are changed 
 func _update_cells(coords: Array[Vector2i], forced_cleanup: bool) -> void:
+	if forced_cleanup: return
 	if not Engine.is_editor_hint(): return
 	for world_coords: Vector2i in coords:
 		_set_display_tiles_for_world_tile(world_coords)


### PR DESCRIPTION
I can't believe I missed this virtual function override possibility when making the changes before. 

Allows you to edit the DualGrid with the display layer visible and have the changes reflected immediately. Should be fairly performant too, only changes the modified tiles, not the whole grid. 

Layering updates are not affected by this change, those still require the manual implementation of forcing updates when the rules change. 

This could be grounds to change other things about the 2.0 release, because I could see users just leaving the display layer visible at all times, which wouldn't reflect changes to the properties of the DualGrid node itself (such as material) without toggling the display preview to force the syncing of inherited properties. It could be changed back to how it was previously, where the `_set` function is used to propagate changes down to the nodes, and then reducing the display layer preview button to just toggle the visibility of the world and display layers without updating the grid or syncing property changes. I didn't make any of these changes because it felt right to discuss it first.

With that said, I think doing a full clear and recalculation on save feels good to me? Even though it really shouldn't be necessary. 

Shame I didn't notice this before but its a nice enough feature to have that I felt it necessary to bring up even though 2.0 just released.